### PR TITLE
Upgrade run-script-os@1.0.3 to fix npm start error 🎉

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1634,6 +1634,14 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -1642,14 +1650,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -2755,9 +2755,10 @@
       }
     },
     "run-script-os": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.0.2.tgz",
-      "integrity": "sha1-mAMz9vakFMFebwLFh5FkgM3ilk8="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/run-script-os/-/run-script-os-1.0.3.tgz",
+      "integrity": "sha512-CRZRyBfQBh+kHq32rZ6A6zxq6Hx3LzgwgcJ8crozey4Va4IMGsTo+agfmlx3/q2As7egn+Jo9w2T6P0//BJg3A==",
+      "dev": true
     },
     "rx": {
       "version": "4.1.0",
@@ -3101,6 +3102,15 @@
         "limiter": "1.1.2"
       }
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3110,15 +3120,6 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -5,17 +5,14 @@
   "main": "index.js",
   "scripts": {
     "start": "run-script-os",
-    "start:win32":
-      "browser-sync start --server --files '**/*.css, **/*.html, **/*.js, !node_modules/**/*' --directory --port 7777 --browser \"C:\\Program Files\\Firefox Developer Edition\\firefox.exe\"",
-    "//":
-      "Hello! If you are having trouble running this command. Try changing Firefox Developer Edition to FirefoxDeveloperEdition",
-    "start:darwin:linux":
-      "browser-sync start --server --files '**/*.css, **/*.html, **/*.js, !node_modules/**/*' --directory --port 7777 --browser 'Firefox Developer Edition'"
+    "start:win32": "browser-sync start --server --files '**/*.css, **/*.html, **/*.js, !node_modules/**/*' --directory --port 7777 --browser \"C:\\Program Files\\Firefox Developer Edition\\firefox.exe\"",
+    "//": "Hello! If you are having trouble running this command. Try changing Firefox Developer Edition to FirefoxDeveloperEdition",
+    "start:darwin:linux": "browser-sync start --server --files '**/*.css, **/*.html, **/*.js, !node_modules/**/*' --directory --port 7777 --browser 'Firefox Developer Edition'"
   },
   "author": "",
   "license": "ISC",
   "devDependencies": {
     "browser-sync": "^2.18.13",
-    "run-script-os": "^1.0.2"
+    "run-script-os": "^1.0.3"
   }
 }


### PR DESCRIPTION
Fixes "env: node\r: No such file or directory"

https://github.com/charlesguse/run-script-os/issues/1

(It seems `npm install` auto-formatted `package.json` with a different change as well, so I brought that along, but just tell if I should revert that change)