### PR TITLE
Updating lodash to version higher than 4.17.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1526,7 +1526,7 @@
       }
     },
     "lodash": {
-      "version": "3.10.1",
+      "version": ">=4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
       "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
       "dev": true


### PR DESCRIPTION
Updating lodash to remove github alert.
<img width="755" alt="screen shot 2019-02-11 at 6 33 54 am" src="https://user-images.githubusercontent.com/11606611/52571329-348fe500-2dca-11e9-8f47-0655a6659ed8.png">
