### PR TITLE
Fix Google Chrome default iframe styles

### DIFF
--- a/22 - Recreating Codepen/style-FINISHED.css
+++ b/22 - Recreating Codepen/style-FINISHED.css
@@ -20,6 +20,11 @@ body {
   margin: 0;
 }
 
+iframe {
+  width: 100%;
+  height: 100%;
+}
+
 h1,
 h2,
 h3,


### PR DESCRIPTION
Google Chrome doesn't adjust the <iframe /> in the same way as Mozilla Firefox does 
![chrome](https://user-images.githubusercontent.com/19862755/76913213-52106780-6884-11ea-8102-7633488d4f71.png)

Here is the fix
![image](https://user-images.githubusercontent.com/19862755/76913261-7e2be880-6884-11ea-90f2-d6be2571ad3c.png)

