### PR TITLE
[ 20 - CSS Grid Image Gallery ] - Vertical align view btn to image

### DIFF
--- a/20 - CSS Grid Image Gallery/image-gallery-FINISHED.html
+++ b/20 - CSS Grid Image Gallery/image-gallery-FINISHED.html
@@ -71,6 +71,7 @@
       width: 100%;
       height: 100%;
       object-fit: cover;
+      overflow: hidden;
     }
 
     .item__overlay {


### PR DESCRIPTION
The View button is not vertically aligned in the final HTML because the image height is used to center the button rather than using the row height. 

Before:
![Screenshot 2025-02-17 at 4 56 22 PM](https://github.com/user-attachments/assets/6ef7b196-1e16-4a78-ac1d-13f8a47111ce)

After:
![Screenshot 2025-02-17 at 4 58 21 PM](https://github.com/user-attachments/assets/e6d3598a-6a32-4e81-bb48-91a266b6c1a1)

